### PR TITLE
Add client-side regex tester tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **PDF Studio** (hero): reorder, rotate, merge, split, page numbers, headers/footers, watermarks, extract text, images↔PDF, stamp QR, quick raster redaction, optimize.
 - **QR & Wi-Fi:** generate QR codes (PNG/SVG).
 - **Image Converter:** HEIC → JPG/PNG/WebP (client-side).
-- **Formatters & Text Tools:** JSON/YAML/XML, case converter, Base64, diff.
+- **Formatters & Text Tools:** JSON/YAML/XML, regex tester (highlight, replace, split), case converter, Base64, diff.
 - **Local-first:** privacy by default.
 
 ---
@@ -37,6 +37,7 @@ npm run dev
 - `/case-converter` — Case converter
 - `/base64` — Base64 encode/decode
 - `/diff` — Text diff
+- `/regex` — Regex tester
 - `/about` — About the project
 
 ---

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -80,7 +80,7 @@ export default function AboutPage() {
             <li><b>PDF Studio:</b> reordering, merging, splitting, numbers, watermarks, redaction, conversions.</li>
             <li><b>QR & Wi-Fi:</b> generate and export QR codes (PNG/SVG).</li>
             <li><b>Image tools:</b> convert common formats right in the browser.</li>
-            <li><b>Formatters & text tools:</b> JSON/YAML/XML, case converter, diff, Base64, etc.</li>
+            <li><b>Formatters & text tools:</b> JSON/YAML/XML, regex tester (highlight, replace, split), case converter, diff, Base64, etc.</li>
           </ul>
           <p className="text-xs text-muted mt-3">
             If a tool ever needs a network call (rare), I’ll call it out in the UI.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,6 +45,7 @@ export const metadata: Metadata = {
     "JSON formatter",
     "Base64 encoder",
     "random generator",
+    "regex tester",
   ],
   openGraph: {
     title: "Utilixy — Quick, private web tools",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
     "image converter",
     "JSON formatter",
     "random generators",
+    "regex tester",
   ],
   openGraph: {
     title: "PDF Studio & Web Tools — Utilixy",
@@ -72,6 +73,11 @@ const tools = [
     href: "/diff",
     title: "Text Diff",
     desc: "Compare two texts and see changes.",
+  },
+  {
+    href: "/regex",
+    title: "Regex Tester",
+    desc: "Experiment with regular expressions, replace and split, and see matches instantly.",
   },
 ];
 

--- a/app/regex/Client.tsx
+++ b/app/regex/Client.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Match {
+  match: string;
+  index: number;
+  groups: string[];
+}
+
+export default function RegexClient() {
+  const [pattern, setPattern] = useState("\\w+");
+  const [flags, setFlags] = useState("g");
+  const [text, setText] = useState("Test 123 test");
+  const [replace, setReplace] = useState("");
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [error, setError] = useState("");
+
+  const flagOpts = [
+    { label: "g", title: "Global" },
+    { label: "i", title: "Ignore case" },
+    { label: "m", title: "Multiline" },
+    { label: "s", title: "DotAll" },
+    { label: "u", title: "Unicode" },
+    { label: "y", title: "Sticky" },
+  ];
+
+  const toggleFlag = (f: string) => {
+    setFlags((prev) =>
+      prev.includes(f) ? prev.replace(f, "") : prev + f
+    );
+  };
+
+  useEffect(() => {
+    try {
+      const re = new RegExp(pattern, flags);
+      const res: Match[] = [];
+      for (const m of text.matchAll(re)) {
+        res.push({
+          match: m[0],
+          index: m.index ?? 0,
+          groups: m.slice(1),
+        });
+      }
+      setMatches(res);
+      setError("");
+    } catch {
+      setMatches([]);
+      setError("Invalid regular expression");
+    }
+  }, [pattern, flags, text]);
+
+  function highlighted() {
+    try {
+      const re = new RegExp(pattern, flags.includes("g") ? flags : flags + "g");
+      return text.replace(re, (m) => `<mark>${m}</mark>`);
+    } catch {
+      return text;
+    }
+  }
+
+  function replaced() {
+    try {
+      const re = new RegExp(pattern, flags);
+      return text.replace(re, replace);
+    } catch {
+      return text;
+    }
+  }
+
+  function split() {
+    try {
+      const re = new RegExp(pattern, flags);
+      return text.split(re);
+    } catch {
+      return [text];
+    }
+  }
+
+  return (
+    <div className="card p-6 md:col-span-2 space-y-6">
+      <div className="grid sm:grid-cols-3 gap-3">
+        <input
+          className="input font-mono"
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          placeholder="Pattern"
+          aria-label="Pattern"
+        />
+        <div className="input flex items-center gap-2 text-sm">
+          {flagOpts.map((f) => (
+            <label key={f.label} title={f.title} className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                className="accent-current"
+                checked={flags.includes(f.label)}
+                onChange={() => toggleFlag(f.label)}
+              />
+              {f.label}
+            </label>
+          ))}
+        </div>
+        <button
+          className="btn"
+          onClick={() => {
+            setPattern("");
+            setFlags("g");
+            setText("");
+            setReplace("");
+            setMatches([]);
+          }}
+        >
+          Clear
+        </button>
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Test string</label>
+        <textarea
+          className="input font-mono"
+          rows={8}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Matches</label>
+        {error ? (
+          <div className="text-red-400 text-sm">{error}</div>
+        ) : matches.length ? (
+          <ol className="text-sm space-y-1">
+            {matches.map((m, i) => (
+              <li key={i}>
+                <code>{m.match}</code> @ {m.index}
+                {m.groups.length ? ` groups: ${m.groups.join(", ")}` : ""}
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <div className="text-muted text-sm">No matches</div>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Replace with</label>
+        <input
+          className="input font-mono"
+          value={replace}
+          onChange={(e) => setReplace(e.target.value)}
+          placeholder="Replacement"
+        />
+        <div className="text-sm mt-2">{replaced()}</div>
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Split</label>
+        <div className="text-sm break-all">{JSON.stringify(split())}</div>
+      </div>
+
+      <div>
+        <label className="block text-sm mb-1">Highlighted</label>
+        <div
+          className="input font-mono whitespace-pre-wrap min-h-[8rem]"
+          dangerouslySetInnerHTML={{ __html: highlighted() }}
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/app/regex/page.tsx
+++ b/app/regex/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import ToolLayout from "@/components/ToolLayout";
+import Client from "./Client";
+
+export const metadata: Metadata = {
+  title: "Regex Tester – Utilixy",
+  description:
+    "Test, replace, and split regular expressions with instant highlighting right in your browser.",
+  openGraph: {
+    title: "Regex Tester – Utilixy",
+    description:
+      "Test, replace, and split regular expressions with instant highlighting right in your browser.",
+    url: "/regex",
+    siteName: "Utilixy",
+    images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Regex Tester – Utilixy",
+    description:
+      "Test, replace, and split regular expressions with instant highlighting right in your browser.",
+    images: ["/icons/icon-512.png"],
+  },
+};
+
+export default function Page() {
+  return (
+    <ToolLayout
+      title="Regex Tester"
+      description="Build, replace, and test regex patterns — everything runs locally."
+    >
+      <Client />
+    </ToolLayout>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/case-converter`, lastModified: new Date() },
     { url: `${base}/cookies`, lastModified: new Date() },
     { url: `${base}/diff`, lastModified: new Date() },
+    { url: `${base}/regex`, lastModified: new Date() },
     { url: `${base}/format`, lastModified: new Date() },
     { url: `${base}/image-converter`, lastModified: new Date() },
     { url: `${base}/pdf`, lastModified: new Date() },

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -4,7 +4,7 @@ export async function GET() {
   const base = 'https://utilixy.com';
   const urls = [
     '/', '/about', '/base64', '/case-converter', '/cookies', '/diff',
-    '/format', '/image-converter', '/pdf', '/privacy', '/qr', '/random', '/terms'
+    '/regex', '/format', '/image-converter', '/pdf', '/privacy', '/qr', '/random', '/terms'
   ];
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,7 @@ const nav = [
   { href: "/pdf", label: "PDF" },
   { href: "/format", label: "Formatter" },
   { href: "/diff", label: "Diff" },
+  { href: "/regex", label: "Regex" },
   { href: "/random", label: "Random" },
 ];
 

--- a/components/ToolMenu.tsx
+++ b/components/ToolMenu.tsx
@@ -13,6 +13,7 @@ const tools = [
   { href: '/format', label: 'JSON / YAML / XML Formatter' },
   { href: '/base64', label: 'Base64 Encoder/Decoder' },
   { href: '/diff', label: 'Text Diff Checker' },
+  { href: '/regex', label: 'Regex Tester' },
 ];
 
 export default function ToolMenu({ onClose }: { onClose: () => void }) {


### PR DESCRIPTION
## Summary
- Expand regex tester with flag toggles, replace, and split helpers
- Mention regex tester features across docs and homepage
- Update regex page metadata for SEO

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc2fda63483298755a3768282e30f