### PR TITLE
Highlight free, signup-free browser tools and add homepage FAQ

### DIFF
--- a/app/image-converter/Hero.tsx
+++ b/app/image-converter/Hero.tsx
@@ -1,12 +1,15 @@
 // app/pdf/Hero.tsx
 export default function Hero() {
   return (
-    <section data-hero="pdf" className="
+    <section
+      data-hero="pdf"
+      className="
       md:col-span-2 relative overflow-hidden rounded-3xl
       border border-[color:var(--line)] bg-[color:var(--bg)]
       p-8 md:p-14 mx-auto w-full max-w-6xl md:min-h-[280px]
       shadow-[0_10px_40px_-10px_hsl(var(--ring)/.25)]
-    ">
+    "
+    >
       {/* soft glows (safe for both themes) */}
       <div className="pointer-events-none absolute -top-24 right-0 h-72 w-96 rounded-full blur-3xl opacity-40 md:opacity-50 bg-[radial-gradient(ellipse_at_top_right,theme(colors.blue.500/18)_0%,transparent_60%)]" />
       <div className="pointer-events-none absolute -bottom-28 -left-10 h-72 w-96 rounded-full blur-3xl opacity-40 md:opacity-50 bg-[radial-gradient(ellipse_at_bottom_left,theme(colors.violet.500/18)_0%,transparent_60%)]" />
@@ -14,27 +17,46 @@ export default function Hero() {
       <div className="relative z-10 grid md:grid-cols-12 gap-8 items-center">
         {/* left */}
         <div className="md:col-span-7">
-          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">Image Studio</h1>
+          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">
+            Image Studio
+          </h1>
           <p className="mt-3 text-base md:text-lg text-muted max-w-prose">
-            Fast, private, and powerful image converter & resizer — right in your browser. No limits.
+            Free, private, and powerful image converter & resizer — right in
+            your browser. No sign-ups, pop-ups, or redirects.
           </p>
           <div className="mt-5 flex flex-wrap gap-2">
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">PNG</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">JPEG</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">WEBP</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">AVIF</span>
-                        <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Convert</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Resize</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Set Quality</span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              PNG
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              JPEG
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              WEBP
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              AVIF
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Convert
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Resize
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Set Quality
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              No sign-up
+            </span>
           </div>
-
         </div>
 
         {/* right quick-cards */}
         <div className="md:col-span-5">
           <div className="grid grid-cols-3 gap-3">
             {[
-              { title: "Merge",   desc: "Combine PDFs." },
+              { title: "Merge", desc: "Combine PDFs." },
               { title: "Reorder", desc: "Drag pages." },
               { title: "Convert", desc: "Images ↔ PDF." },
             ].map((c) => (

--- a/app/image-converter/head.tsx
+++ b/app/image-converter/head.tsx
@@ -16,8 +16,8 @@ export default function Head() {
             description:
               "Convert, resize and batch-download images (PNG, JPG, WebP, AVIF, HEIC) locally in your browser.",
             url: "https://utilixy.com/image-converter",
-            publisher: { "@type": "Organization", name: "Utilixy" }
-          })
+            publisher: { "@type": "Organization", name: "Utilixy" },
+          }),
         }}
       />
 
@@ -35,51 +35,50 @@ export default function Head() {
                 name: "Is anything uploaded to a server?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text:
-                    "No. All conversions run locally in your browser—files never leave your device."
-                }
+                  text: "No. All conversions run locally in your browser—files never leave your device.",
+                },
               },
               {
                 "@type": "Question",
                 name: "Which formats can I convert?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text:
-                    "PNG, JPEG/JPG, WebP, AVIF and HEIC (iPhone photos) are supported as inputs. Outputs include PNG, JPG, WebP and AVIF."
-                }
+                  text: "PNG, JPEG/JPG, WebP, AVIF and HEIC (iPhone photos) are supported as inputs. Outputs include PNG, JPG, WebP and AVIF.",
+                },
               },
               {
                 "@type": "Question",
                 name: "Can I resize images at the same time?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text:
-                    "Yes. Enter a width and/or height before clicking Convert. Leave a field blank to preserve the original dimension."
-                }
+                  text: "Yes. Enter a width and/or height before clicking Convert. Leave a field blank to preserve the original dimension.",
+                },
               },
               {
                 "@type": "Question",
                 name: "Is the tool free?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text: "Yes—100 % free and ad-supported. No signup required."
-                }
+                  text: "Yes—100 % free and ad-supported. No signup required.",
+                },
               },
               {
                 "@type": "Question",
                 name: "Does it work offline?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text:
-                    "Once the page is loaded it keeps working without internet, because all logic is client-side JavaScript."
-                }
-              }
-            ]
-          })
+                  text: "Once the page is loaded it keeps working without internet, because all logic is client-side JavaScript.",
+                },
+              },
+            ],
+          }),
         }}
       />
     </>
   );
 }
 
-<meta name="description" content="Convert images locally to PNG, JPEG, WEBP, HEIC, and AVIF. Resize, set quality, and download—no uploads." />
+<meta
+  name="description"
+  content="Convert images locally to PNG, JPEG, WEBP, HEIC, and AVIF. Resize, set quality, and download—no uploads, sign-up, pop-ups, or redirects."
+/>;

--- a/app/image-converter/page.tsx
+++ b/app/image-converter/page.tsx
@@ -2,16 +2,16 @@ import type { Metadata } from "next";
 import ToolLayout from "@/components/ToolLayout";
 import Client from "./Client";
 import Ad from "@/components/ads/Ad";
-import Hero from "./Hero";               // (use your actual path)
-
+import Hero from "./Hero"; // (use your actual path)
 
 export const metadata: Metadata = {
   title: "Image Converter (PNG / JPEG / WEBP + HEIC) — Utilixy",
-  description: "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once.",
+  description:
+    "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once. Free with no sign-up, pop-ups, redirects, or uploads.",
   openGraph: {
     title: "Image Converter (PNG / JPEG / WEBP + HEIC) — Utilixy",
     description:
-      "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once.",
+      "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once. Free with no sign-up, pop-ups, redirects, or uploads.",
     url: "/image-converter",
     siteName: "Utilixy",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     card: "summary",
     title: "Image Converter (PNG / JPEG / WEBP + HEIC) — Utilixy",
     description:
-      "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once.",
+      "Convert images privately in your browser — supports PNG, JPEG, WEBP, and HEIC. Adjust quality, choose background color for JPEG, and convert multiple images at once. Free with no sign-up, pop-ups, redirects, or uploads.",
     images: ["/icons/icon-512.png"],
   },
 };
@@ -30,17 +30,11 @@ export default function Page() {
   return (
     <ToolLayout
       title="Image Converter"
-      description="Convert images locally. Choose format, quality, and background for JPEG. Drag & drop multiple files."
-data-image      
-
+      description="Free, private image converter. Choose format, quality, and background for JPEG without sign-ups, pop-ups, or redirects."
+      data-image
     >
-        <Hero />
+      <Hero />
       <Client />
-
-   
-
-
-
     </ToolLayout>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import Ad from "@/components/ads/Ad"; // Multiplex wrapper
 export const metadata: Metadata = {
   title: "PDF Studio & Web Tools — Utilixy",
   description:
-    "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local and private.",
+    "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
   keywords: [
     "PDF Studio",
     "web tools",
@@ -14,11 +14,15 @@ export const metadata: Metadata = {
     "JSON formatter",
     "random generators",
     "regex tester",
+    "free online tools",
+    "no sign up",
+    "no pop ups",
+    "no redirects",
   ],
   openGraph: {
     title: "PDF Studio & Web Tools — Utilixy",
     description:
-      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local and private.",
+      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
     url: "/",
     siteName: "Utilixy",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
@@ -28,7 +32,7 @@ export const metadata: Metadata = {
     card: "summary",
     title: "PDF Studio & Web Tools — Utilixy",
     description:
-      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local and private.",
+      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
     images: ["/icons/icon-512.png"],
   },
 };
@@ -81,6 +85,35 @@ const tools = [
   },
 ];
 
+const faq = [
+  {
+    q: "Is Utilixy free to use?",
+    a: "Yes. Every tool is 100% free with no hidden costs or subscriptions.",
+  },
+  {
+    q: "Do I need to create an account?",
+    a: "No sign-up or registration is required — just open a tool and start working.",
+  },
+  {
+    q: "Will I see pop-ups or be redirected?",
+    a: "No. Utilixy avoids intrusive pop-ups or redirects so you can stay focused.",
+  },
+  {
+    q: "Are my files uploaded or stored anywhere?",
+    a: "Everything runs locally in your browser. Your files never leave your device.",
+  },
+];
+
+const faqLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faq.map(({ q, a }) => ({
+    "@type": "Question",
+    name: q,
+    acceptedAnswer: { "@type": "Answer", text: a },
+  })),
+};
+
 export default function HomePage() {
   return (
     <div className="grid gap-10">
@@ -98,15 +131,19 @@ export default function HomePage() {
         <div className="relative px-6 py-10 md:px-10 md:py-14 grid gap-8">
           <div className="grid gap-3 text-center">
             <span className="mx-auto inline-flex items-center gap-2 rounded-full border border-[hsl(var(--ring)/.4)] px-3 py-1 text-xs uppercase tracking-wide">
-              Powerful · Private · Free
+              Powerful · Private · Free · No sign-up
             </span>
             <h1 className="text-[2.3rem] leading-tight font-semibold tracking-tight md:text-[2.8rem]">
-            <span className="text-[hsl(var(--ring))]">Utilixy</span> Web Tools
+              <span className="text-[hsl(var(--ring))]">Utilixy</span> Web Tools
             </h1>
-          
 
             <p className="mx-auto mt-2 text-[1.05rem] text-muted max-w-[70ch]">
-             Edit, merge, split & convert PDFs, extract text, add watermarks & page numbers, optimize images (AVIF, PNG, JPEG, WebP) — <b>fast, private, and entirely in your browser, free forever.</b>
+              Edit, merge, split & convert PDFs, extract text, add watermarks &
+              page numbers, optimize images (AVIF, PNG, JPEG, WebP) —{" "}
+              <b>
+                fast, private, and entirely in your browser, free forever with
+                no sign-up, pop-ups, or redirects.
+              </b>
             </p>
             {/* CTAs */}
             <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
@@ -119,7 +156,6 @@ export default function HomePage() {
               <a href="#tools" className="btn">
                 Browse all tools
               </a>
-          
             </div>
 
             {/* Mention other tools inline */}
@@ -223,6 +259,28 @@ export default function HomePage() {
           ))}
         </div>
       </section>
+
+      {/* FAQ for homepage */}
+      <section className="mt-10">
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg md:text-xl font-semibold mb-2">
+            Utilixy — FAQ
+          </h2>
+          <div className="space-y-2">
+            {faq.map(({ q, a }, i) => (
+              <details key={i} className="card--flat p-3">
+                <summary className="font-medium cursor-pointer">{q}</summary>
+                <div className="mt-2 text-sm text-muted">{a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      </section>
+
       {/* Homepage bottom ad: Multiplex, out of the way */}
       <section className="mt-10">
         <Ad slot="homeMultiplex" format="autorelaxed" minHeight={320} />

--- a/app/pdf/Hero.tsx
+++ b/app/pdf/Hero.tsx
@@ -1,12 +1,15 @@
 // app/pdf/Hero.tsx
 export default function Hero() {
   return (
-    <section data-hero="pdf" className="
+    <section
+      data-hero="pdf"
+      className="
       md:col-span-2 relative overflow-hidden rounded-3xl
       border border-[color:var(--line)] bg-[color:var(--bg)]
       p-8 md:p-14 mx-auto w-full max-w-6xl md:min-h-[280px]
       shadow-[0_10px_40px_-10px_hsl(var(--ring)/.25)]
-    ">
+    "
+    >
       {/* soft glows (safe for both themes) */}
       <div className="pointer-events-none absolute -top-24 right-0 h-72 w-96 rounded-full blur-3xl opacity-40 md:opacity-50 bg-[radial-gradient(ellipse_at_top_right,theme(colors.blue.500/18)_0%,transparent_60%)]" />
       <div className="pointer-events-none absolute -bottom-28 -left-10 h-72 w-96 rounded-full blur-3xl opacity-40 md:opacity-50 bg-[radial-gradient(ellipse_at_bottom_left,theme(colors.violet.500/18)_0%,transparent_60%)]" />
@@ -14,14 +17,26 @@ export default function Hero() {
       <div className="relative z-10 grid md:grid-cols-12 gap-8 items-center">
         {/* left */}
         <div className="md:col-span-7">
-          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">PDF Studio</h1>
+          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">
+            PDF Studio
+          </h1>
           <p className="mt-3 text-base md:text-lg text-muted max-w-prose">
-            Fast, private, and powerful PDF tools — right in your browser. No uploads, no limits.
+            Free, private, and powerful PDF tools — right in your browser. No
+            sign-ups, pop-ups, redirects, or uploads.
           </p>
           <div className="mt-5 flex flex-wrap gap-2">
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Private</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Local-first</span>
-            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">Free</span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Private
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Local-first
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              Free
+            </span>
+            <span className="rounded-full border border-[color:var(--line)]/70 px-3 py-1 text-xs">
+              No sign-up
+            </span>
           </div>
         </div>
 
@@ -29,7 +44,7 @@ export default function Hero() {
         <div className="md:col-span-5">
           <div className="grid grid-cols-3 gap-3">
             {[
-              { title: "Merge",   desc: "Combine PDFs." },
+              { title: "Merge", desc: "Combine PDFs." },
               { title: "Reorder", desc: "Drag pages." },
               { title: "Convert", desc: "Images ↔ PDF." },
             ].map((c) => (

--- a/app/pdf/page.tsx
+++ b/app/pdf/page.tsx
@@ -1,18 +1,18 @@
 // app/pdf/page.tsx
 import React from "react";
 import ToolLayout from "@/components/ToolLayout";
-import Hero from "./Hero";               // (use your actual path)
-import Client from "./Client";           // (use your actual path)
+import Hero from "./Hero"; // (use your actual path)
+import Client from "./Client"; // (use your actual path)
 
 export const metadata = {
   title: "PDF Studio — Free Online PDF Tools (Private & Local-first)",
   description:
-    "Merge, split, reorder, rotate, watermark, convert images ↔ PDF, extract text, redact, fill forms, and compress — all in your browser. No uploads, no limits.",
+    "Merge, split, reorder, rotate, watermark, convert images ↔ PDF, extract text, redact, fill forms, and compress — all in your browser. Free with no sign-up, pop-ups, redirects, or uploads.",
   alternates: { canonical: "https://yourdomain.com/pdf" },
   openGraph: {
     title: "PDF Studio — Free Online PDF Tools",
     description:
-      "Fast, private PDF tools that run locally in your browser. No uploads required.",
+      "Fast, private PDF tools that run locally in your browser. Free with no sign-up, pop-ups, redirects, or uploads.",
     url: "https://yourdomain.com/pdf",
     siteName: "Utilixy",
     type: "website",
@@ -21,7 +21,7 @@ export const metadata = {
     card: "summary_large_image",
     title: "PDF Studio — Free Online PDF Tools",
     description:
-      "Fast, private PDF tools that run locally in your browser. No uploads required.",
+      "Fast, private PDF tools that run locally in your browser. Free with no sign-up, pop-ups, redirects, or uploads.",
   },
 };
 
@@ -29,7 +29,7 @@ export default function Page() {
   return (
     <ToolLayout
       title="PDF Studio"
-      description="Fast, private, and powerful PDF tools — right in your browser. No uploads, no limits."
+      description="Free, private, and powerful PDF tools — right in your browser. No sign-ups, pop-ups, redirects, or uploads."
       align="center"
       data-pdf
     >
@@ -38,7 +38,6 @@ export default function Page() {
 
       {/* Left/Right grid item #2 — the interactive tool stage */}
       <Client />
-
     </ToolLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Emphasize free, no‑signup, no pop‑ups or redirects in site metadata and hero copy
- Add structured FAQ to homepage covering cost, account needs, pop‑ups and local processing
- Update PDF and Image Converter pages to reflect the same messaging

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_689e265f0e0083299c88e3c1415d5dae