### PR TITLE
fix: align image FAQ with results panel

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -804,8 +804,10 @@ main:has(#seo-content) .tool-panels{
 
 /* keep it from feeling too wide on huge screens, but still half-ish width */
 @media (min-width: 1024px){
-  #seo-content .card{
+  [data-pdf] #seo-content .card{
     max-width: 720px;                     /* tune if you want it wider/narrower */
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 

--- a/app/image-converter/Client.tsx
+++ b/app/image-converter/Client.tsx
@@ -386,6 +386,48 @@ export default function Client() {
     router.replace(`/image-converter?${sp.toString()}`, { scroll: false });
   };
 
+  // FAQ content
+  const faq = [
+    {
+      q: "Do my images upload to a server?",
+      a: "No. All conversions run locally in your browser—files never leave your device.",
+    },
+    {
+      q: "Which formats can I convert?",
+      a: "PNG, JPG, WebP, AVIF and HEIC are supported. You can also export images as a single PDF.",
+    },
+    {
+      q: "What editing tools are available?",
+      a: "Crop, resize, rotate/flip, compress by quality, add text watermarks, strip EXIF metadata, and even combine images into a PDF.",
+    },
+    {
+      q: "Can I convert to AVIF?",
+      a: "Yes. The app can encode AVIF directly in your browser. If your browser lacks native support, a built-in WebAssembly encoder is used automatically.",
+    },
+    {
+      q: "Can I batch-resize or download as ZIP?",
+      a: "Yes. Add multiple images, set options, and download them individually or as a ZIP archive.",
+    },
+    {
+      q: "Is the tool free?",
+      a: "Yes—100% free and ad-supported. No sign-up required.",
+    },
+    {
+      q: "Does it work offline?",
+      a: "Once loaded, it continues working without internet because all processing is client-side JavaScript.",
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
   // uploader
   function onPick(files: File[]) {
     const arr = files.map((f) => ({
@@ -1061,6 +1103,24 @@ export default function Client() {
             <pre className="mt-4 p-3 bg-black/30 rounded text-xs overflow-auto max-h-60">{log.join("\n")}</pre>
           )}
         </div>
+
+        <section id="seo-content" className="md:col-start-2">
+          <div className="card p-4 md:p-6">
+            <h2 className="text-lg md:text-xl font-semibold mb-2">Image Studio — FAQ</h2>
+            <div className="space-y-2">
+              {faq.map(({ q, a }, i) => (
+                <details key={i} className="card--flat p-3">
+                  <summary className="font-medium cursor-pointer">{q}</summary>
+                  <div className="mt-2 text-sm text-muted">{a}</div>
+                </details>
+              ))}
+            </div>
+          </div>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+          />
+        </section>
       </div>
     </section>
   );

--- a/app/image-converter/page.tsx
+++ b/app/image-converter/page.tsx
@@ -29,70 +29,12 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
-  const faq = [
-    {
-      q: "Do my images upload to a server?",
-      a: "No. All conversions run locally in your browser—files never leave your device.",
-    },
-    {
-      q: "Which formats can I convert?",
-      a: "PNG, JPG, WebP, AVIF and HEIC are supported. You can also export images as a single PDF.",
-    },
-    {
-      q: "What editing tools are available?",
-      a: "Crop, resize, rotate/flip, compress by quality, add text watermarks, strip EXIF metadata, and even combine images into a PDF.",
-    },
-    {
-      q: "Can I convert to AVIF?",
-      a: "Yes. The app can encode AVIF directly in your browser. If your browser lacks native support, a built-in WebAssembly encoder is used automatically.",
-    },
-    {
-      q: "Can I batch-resize or download as ZIP?",
-      a: "Yes. Add multiple images, set options, and download them individually or as a ZIP archive.",
-    },
-    {
-      q: "Is the tool free?",
-      a: "Yes—100% free and ad-supported. No sign-up required.",
-    },
-    {
-      q: "Does it work offline?",
-      a: "Once loaded, it continues working without internet because all processing is client-side JavaScript.",
-    },
-  ];
-
-  const faqLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faq.map(({ q, a }) => ({
-      "@type": "Question",
-      name: q,
-      acceptedAnswer: { "@type": "Answer", text: a },
-    })),
-  };
-
   return (
     <>
       <Hero />
       <Suspense fallback={<div className="p-4 text-sm text-muted">Loading image tool…</div>}>
         <Client />
       </Suspense>
-      <section id="seo-content" className="seo-half">
-        <div className="card p-4 md:p-6">
-          <h2 className="text-lg md:text-xl font-semibold mb-2">Image Studio — FAQ</h2>
-          <div className="space-y-2">
-            {faq.map(({ q, a }, i) => (
-              <details key={i} className="card--flat p-3">
-                <summary className="font-medium cursor-pointer">{q}</summary>
-                <div className="mt-2 text-sm text-muted">{a}</div>
-              </details>
-            ))}
-          </div>
-        </div>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
-        />
-      </section>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- embed Image Studio FAQ inside tool grid so it lines up with the results panel
- scope FAQ card width rule to PDF pages to avoid centering on image tools
- simplify Image Studio page component after moving FAQ logic into client component

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a240a755fc8329b239cf58210f4bfb