### PR TITLE
Align Word↔PDF tool UI with other PDF tools

### DIFF
--- a/app/pdf/tools/ToolDocToPdf.tsx
+++ b/app/pdf/tools/ToolDocToPdf.tsx
@@ -66,16 +66,7 @@ export default function ToolDocToPdfUX() {
   }
 
   return (
-    <div className="space-y-3">
-      <input
-        type="file"
-        accept=".doc,.docx"
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) handle(f);
-        }}
-      />
-      {busy && <p className="text-sm text-muted">Converting…</p>}
+    <div className="card p-6 space-y-4">
       <ToolHelp>
         <>
           <p>
@@ -90,6 +81,19 @@ export default function ToolDocToPdfUX() {
           </ol>
         </>
       </ToolHelp>
+      <label className="block">
+        <span className="text-sm">Word document</span>
+        <input
+          type="file"
+          accept=".doc,.docx"
+          className="input mt-1"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handle(f);
+          }}
+        />
+      </label>
+      {busy && <p className="text-sm text-muted">Converting…</p>}
     </div>
   );
 }

--- a/app/pdf/tools/ToolPdfToDoc.tsx
+++ b/app/pdf/tools/ToolPdfToDoc.tsx
@@ -73,16 +73,7 @@ export default function ToolPdfToDocUX() {
   }
 
   return (
-    <div className="space-y-3">
-      <input
-        type="file"
-        accept="application/pdf"
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) handle(f);
-        }}
-      />
-      {busy && <p className="text-sm text-muted">Converting…</p>}
+    <div className="card p-6 space-y-4">
       <ToolHelp>
         <>
           <p>
@@ -97,6 +88,19 @@ export default function ToolPdfToDocUX() {
           </ol>
         </>
       </ToolHelp>
+      <label className="block">
+        <span className="text-sm">PDF file</span>
+        <input
+          type="file"
+          accept="application/pdf"
+          className="input mt-1"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handle(f);
+          }}
+        />
+      </label>
+      {busy && <p className="text-sm text-muted">Converting…</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Match Word→PDF and PDF→Word tool layouts with other PDF tools by placing tooltips above inputs and adding consistent styling

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cefa2fc083298031def8463e952c