### PR TITLE
Fix mobile heading and drop extra FAQ

### DIFF
--- a/app/image-converter/Client.tsx
+++ b/app/image-converter/Client.tsx
@@ -371,48 +371,6 @@ const TOOLS: { id: ToolId; label: string }[] = [
 
 type Picked = { file: File; name: string; url: string };
 
-// FAQ content for SEO and on-page questions
-const faq = [
-  {
-    q: "Do my images upload to a server?",
-    a: "No. All conversions run locally in your browser—files never leave your device.",
-  },
-  {
-    q: "Which formats can I convert?",
-    a: "PNG, JPG, WebP, AVIF and HEIC are supported. You can also export images as a single PDF.",
-  },
-  {
-    q: "What editing tools are available?",
-    a: "Crop, resize, rotate/flip, compress by quality, add text watermarks, strip EXIF metadata, and even combine images into a PDF.",
-  },
-  {
-    q: "Can I convert to AVIF?",
-    a: "Yes. The app can encode AVIF directly in your browser. If your browser lacks native support, a built-in WebAssembly encoder is used automatically.",
-  },
-  {
-    q: "Can I batch-resize or download as ZIP?",
-    a: "Yes. Add multiple images, set options, and download them individually or as a ZIP archive.",
-  },
-  {
-    q: "Is the tool free?",
-    a: "Yes—100% free and ad-supported. No sign-up required.",
-  },
-  {
-    q: "Does it work offline?",
-    a: "Once loaded, it continues working without internet because all processing is client-side JavaScript.",
-  },
-];
-
-const faqLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: faq.map(({ q, a }) => ({
-    "@type": "Question",
-    name: q,
-    acceptedAnswer: { "@type": "Answer", text: a },
-  })),
-};
-
 export default function Client() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -524,50 +482,8 @@ export default function Client() {
     router.replace(`/image-converter?${sp.toString()}`, { scroll: false });
   };
 
-  // FAQ content
-  const faq = [
-    {
-      q: "Do my images upload to a server?",
-      a: "No. All conversions run locally in your browser—files never leave your device.",
-    },
-    {
-      q: "Which formats can I convert?",
-      a: "PNG, JPG, WebP, AVIF and HEIC are supported. You can also export images as a single PDF.",
-    },
-    {
-      q: "What editing tools are available?",
-      a: "Crop, resize, rotate/flip, compress by quality, add text watermarks, strip EXIF metadata, and even combine images into a PDF.",
-    },
-    {
-      q: "Can I convert to AVIF?",
-      a: "Yes. The app can encode AVIF directly in your browser. If your browser lacks native support, a built-in WebAssembly encoder is used automatically.",
-    },
-    {
-      q: "Can I batch-resize or download as ZIP?",
-      a: "Yes. Add multiple images, set options, and download them individually or as a ZIP archive.",
-    },
-    {
-      q: "Is the tool free?",
-      a: "Yes—100% free and ad-supported. No sign-up required.",
-    },
-    {
-      q: "Does it work offline?",
-      a: "Once loaded, it continues working without internet because all processing is client-side JavaScript.",
-    },
-  ];
-
-  const faqLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faq.map(({ q, a }) => ({
-      "@type": "Question",
-      name: q,
-      acceptedAnswer: { "@type": "Answer", text: a },
-    })),
-  };
-
-  // uploader
-  function onPick(files: File[]) {
+    // uploader
+    function onPick(files: File[]) {
     const arr = files.map((f) => ({
       file: f,
       name: f.name.replace(/\.[^.]+$/, ""),
@@ -897,12 +813,12 @@ export default function Client() {
 
         {/* Stage */}
         <div className="card p-4">
+          {activeLabel && (
+            <h2 className="text-2xl font-bold mb-4 text-center text-[#2B67F3]">{activeLabel}</h2>
+          )}
           <div className="grid lg:grid-cols-2 gap-4">
             {/* Left: preview + thumbs (unchanged) */}
             <div className="order-2 lg:order-1">
-              {activeLabel && (
-                <h2 className="text-2xl font-bold mb-4 text-center text-[#2B67F3]">{activeLabel}</h2>
-              )}
               <h3 className="text-sm font-medium mb-2">Live Preview</h3>
 
               {picked.length > 0 ? (
@@ -1537,26 +1453,6 @@ export default function Client() {
             </pre>
           )}
         </div>
-
-        <section id="seo-content" className="md:col-start-2">
-          <div className="card p-4 md:p-6">
-            <h2 className="text-lg md:text-xl font-semibold mb-2">
-              Image Studio — FAQ
-            </h2>
-            <div className="space-y-2">
-              {faq.map(({ q, a }, i) => (
-                <details key={i} className="card--flat p-3">
-                  <summary className="font-medium cursor-pointer">{q}</summary>
-                  <div className="mt-2 text-sm text-muted">{a}</div>
-                </details>
-              ))}
-            </div>
-          </div>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
-          />
-        </section>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Show active image tool heading above controls for better mobile layout
- Remove duplicate FAQ block from image tools to avoid full-width duplication

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d08524bc83299020f1a34aa92c29