### PR TITLE
Align tool pages with regex layout and SEO

### DIFF
--- a/app/base64/page.tsx
+++ b/app/base64/page.tsx
@@ -5,11 +5,19 @@ import Client from "./Client";
 export const metadata: Metadata = {
   title: "Base64 Encoder / Decoder – Utilixy",
   description: "Convert text or files to and from Base64 instantly in your browser.",
-  alternates: { canonical: "https://utilixy.com/base64" },
+  alternates: { canonical: "/base64" },
+  keywords: [
+    "base64 encoder",
+    "base64 decoder",
+    "text to base64",
+    "file to base64",
+    "base64 converter",
+    "online base64",
+  ],
   openGraph: {
     title: "Base64 Encoder / Decoder – Utilixy",
     description: "Convert text or files to and from Base64 instantly in your browser.",
-    url: "https://utilixy.com/base64",
+    url: "/base64",
     siteName: "Utilixy",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
     type: "website",
@@ -61,6 +69,63 @@ export default function Page() {
       title="Base64 Encoder / Decoder"
       description="Encode or decode Base64 strings or files — all locally, nothing is uploaded."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste text or drop a file, then choose <strong>Encode</strong> or
+              <strong> Decode</strong>. The converted output appears instantly with nothing
+              sent to a server.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                <strong>Encode</strong> turns text or files into a Base64 string.
+              </li>
+              <li>
+                <strong>Decode</strong> converts a Base64 string back to text or a
+                downloadable file.
+              </li>
+              <li>
+                <strong>Copy</strong> buttons let you grab the result quickly.
+              </li>
+            </ul>
+            <p className="mt-3">
+              Tip: large files need more memory because everything runs locally.
+            </p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste text or drop a file, then choose <strong>Encode</strong> or
+              <strong> Decode</strong>. The converted output appears instantly with nothing
+              sent to a server.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                <strong>Encode</strong> turns text or files into a Base64 string.
+              </li>
+              <li>
+                <strong>Decode</strong> converts a Base64 string back to text or a
+                downloadable file.
+              </li>
+              <li>
+                <strong>Copy</strong> buttons let you grab the result quickly.
+              </li>
+            </ul>
+            <p className="mt-3">
+              Tip: large files need more memory because everything runs locally.
+            </p>
+          </div>
+        </details>
+      </div>
+
       <Client />
       <section id="seo-content" className="seo-half">
         <div className="card p-4 md:p-6">

--- a/app/case-converter/page.tsx
+++ b/app/case-converter/page.tsx
@@ -6,6 +6,16 @@ export const metadata: Metadata = {
   title: "Case Converter – Utilixy",
   description:
     "UPPER↔lower, Title, Sentence, Capitalize, Slug, camelCase, PascalCase, snake_case, kebab-case. All client-side.",
+  alternates: { canonical: "/case-converter" },
+  keywords: [
+    "case converter",
+    "text transformer",
+    "uppercase to lowercase",
+    "camelcase",
+    "snake case",
+    "kebab case",
+    "title case",
+  ],
   openGraph: {
     title: "Case Converter – Utilixy",
     description:
@@ -25,12 +35,105 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
+  const faq = [
+    {
+      q: "Is my text sent anywhere?",
+      a: "No. Conversions happen instantly in your browser—nothing is uploaded.",
+    },
+    {
+      q: "Which case styles are supported?",
+      a: "Upper, lower, title, sentence, slug, camelCase, PascalCase, snake_case and kebab-case.",
+    },
+    {
+      q: "Can I copy results easily?",
+      a: "Yes. Use the copy buttons beside each output field.",
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
   return (
     <ToolLayout
       title="Case Converter / Text Transformer"
       description="Paste text, choose a transform, and copy the result. Nothing leaves your browser."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste text, pick a <strong>case style</strong>, and the transformed text
+              updates instantly without leaving your device.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                Convert between upper, lower, title, sentence and more.
+              </li>
+              <li>
+                Generate slugs, camelCase or snake_case for programming.
+              </li>
+              <li>
+                Copy the result with one click.
+              </li>
+            </ul>
+            <p className="mt-3">Tip: you can edit the output further before copying.</p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste text, pick a <strong>case style</strong>, and the transformed text
+              updates instantly without leaving your device.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                Convert between upper, lower, title, sentence and more.
+              </li>
+              <li>
+                Generate slugs, camelCase or snake_case for programming.
+              </li>
+              <li>
+                Copy the result with one click.
+              </li>
+            </ul>
+            <p className="mt-3">Tip: you can edit the output further before copying.</p>
+          </div>
+        </details>
+      </div>
+
       <Client />
+      <section id="seo-content" className="seo-half">
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg md:text-xl font-semibold mb-2">
+            Case Converter — FAQ
+          </h2>
+          <div className="space-y-2">
+            {faq.map(({ q, a }, i) => (
+              <details key={i} className="card--flat p-3">
+                <summary className="font-medium cursor-pointer">{q}</summary>
+                <div className="mt-2 text-sm text-muted">{a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      </section>
     </ToolLayout>
   );
 }

--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   title: "Text Difference Checker — Utilixy",
   description:
     "Compare two blocks of text and highlight additions, deletions, and unchanged parts. Everything runs in your browser.",
-  alternates: { canonical: "https://utilixy.com/diff" },
+  alternates: { canonical: "/diff" },
   robots: { index: true, follow: true },
   keywords: [
     "text diff",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     title: "Text Difference Checker — Utilixy",
     description:
       "Compare two blocks of text and highlight additions, deletions, and unchanged parts. Everything runs in your browser.",
-    url: "https://utilixy.com/diff",
+    url: "/diff",
     siteName: "Utilixy",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
     type: "website",
@@ -74,6 +74,61 @@ export default function Page() {
       title="Text Difference Checker"
       description="Paste the original text on the left and the changed text on the right. See what’s been added and removed."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste your <strong>original</strong> text on the left and the
+              <strong> changed</strong> text on the right. Differences appear instantly and
+              stay on your device.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                <strong>Inline</strong> view shows additions and deletions within lines.
+              </li>
+              <li>
+                <strong>Side-by-side</strong> view compares entire lines next to each other.
+              </li>
+              <li>
+                Switch modes or copy results without leaving the page.
+              </li>
+            </ul>
+            <p className="mt-3">
+              Tip: large texts may take longer to compute depending on your device.
+            </p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste your <strong>original</strong> text on the left and the
+              <strong> changed</strong> text on the right. Differences appear instantly and
+              stay on your device.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>
+                <strong>Inline</strong> view shows additions and deletions within lines.
+              </li>
+              <li>
+                <strong>Side-by-side</strong> view compares entire lines next to each other.
+              </li>
+              <li>
+                Switch modes or copy results without leaving the page.
+              </li>
+            </ul>
+            <p className="mt-3">
+              Tip: large texts may take longer to compute depending on your device.
+            </p>
+          </div>
+        </details>
+      </div>
+
       <Client />
       <section id="seo-content" className="seo-half">
         <div className="card p-4 md:p-6">

--- a/app/format/page.tsx
+++ b/app/format/page.tsx
@@ -7,6 +7,15 @@ export const metadata: Metadata = {
   title: "JSON / YAML / XML Formatter & Validator — Utilixy",
   description:
     "Format and validate JSON, YAML, or XML instantly in your browser. Auto-detect, pretty-print or minify. Private & fast.",
+  alternates: { canonical: "/format" },
+  keywords: [
+    "json formatter",
+    "yaml formatter",
+    "xml formatter",
+    "json validator",
+    "online formatter",
+    "pretty print json",
+  ],
   openGraph: {
     title: "JSON / YAML / XML Formatter & Validator — Utilixy",
     description:
@@ -24,12 +33,95 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
+  const faq = [
+    {
+      q: "Is my code sent to a server?",
+      a: "No. Formatting and validation happen entirely in your browser.",
+    },
+    {
+      q: "Which formats are supported?",
+      a: "JSON, YAML, and XML with auto-detection and conversion between them.",
+    },
+    {
+      q: "Can I minify as well as pretty-print?",
+      a: "Yes. Toggle between formatted and minified output.",
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
   return (
     <ToolLayout
       title="JSON / YAML / XML Formatter"
       description="Paste code, auto-detect the format, and pretty-print or minify — all client-side."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste your <strong>JSON</strong>, <strong>YAML</strong> or
+              <strong> XML</strong>. The tool detects the format and instantly
+              pretty-prints or minifies it locally.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Validate structure and highlight errors.</li>
+              <li>Convert between JSON, YAML and XML.</li>
+              <li>Copy formatted or minified output with one click.</li>
+            </ul>
+            <p className="mt-3">Tip: large documents may take longer to process.</p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Paste your <strong>JSON</strong>, <strong>YAML</strong> or
+              <strong> XML</strong>. The tool detects the format and instantly
+              pretty-prints or minifies it locally.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Validate structure and highlight errors.</li>
+              <li>Convert between JSON, YAML and XML.</li>
+              <li>Copy formatted or minified output with one click.</li>
+            </ul>
+            <p className="mt-3">Tip: large documents may take longer to process.</p>
+          </div>
+        </details>
+      </div>
+
       <Client />
+      <section id="seo-content" className="seo-half">
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg md:text-xl font-semibold mb-2">
+            JSON / YAML / XML Formatter — FAQ
+          </h2>
+          <div className="space-y-2">
+            {faq.map(({ q, a }, i) => (
+              <details key={i} className="card--flat p-3">
+                <summary className="font-medium cursor-pointer">{q}</summary>
+                <div className="mt-2 text-sm text-muted">{a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      </section>
     </ToolLayout>
   );
 }

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -37,13 +37,92 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
+  const faq = [
+    {
+      q: "Is everything generated locally?",
+      a: "Yes. QR codes are rendered in your browser and never uploaded.",
+    },
+    {
+      q: "Can I customize colors or size?",
+      a: "Absolutely. Adjust foreground, background, margin and module size before downloading.",
+    },
+    {
+      q: "What types of codes can I create?",
+      a: "Wi‑Fi (WPA/WEP/Open) plus standard text, URL, email and SMS QR codes.",
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
   return (
     <ToolLayout
       title="Wi-Fi QR Code Generator"
       description="Share your network instantly: scan to connect. Adjust size, margin and colors, and export PNG or SVG."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Enter Wi‑Fi credentials or standard text and the QR code updates instantly.
+              Scan with a phone to connect or view the content.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Choose Wi‑Fi, text, URL, email or SMS modes.</li>
+              <li>Customize colors, margin and size.</li>
+              <li>Download the code as PNG or SVG.</li>
+            </ul>
+            <p className="mt-3">Tip: keep contrast high for reliable scanning.</p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Enter Wi‑Fi credentials or standard text and the QR code updates instantly.
+              Scan with a phone to connect or view the content.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Choose Wi‑Fi, text, URL, email or SMS modes.</li>
+              <li>Customize colors, margin and size.</li>
+              <li>Download the code as PNG or SVG.</li>
+            </ul>
+            <p className="mt-3">Tip: keep contrast high for reliable scanning.</p>
+          </div>
+        </details>
+      </div>
+
       <Client />
-    
+
+      <section id="seo-content" className="seo-half">
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg md:text-xl font-semibold mb-2">Wi-Fi QR Code Generator — FAQ</h2>
+          <div className="space-y-2">
+            {faq.map(({ q, a }, i) => (
+              <details key={i} className="card--flat p-3">
+                <summary className="font-medium cursor-pointer">{q}</summary>
+                <div className="mt-2 text-sm text-muted">{a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      </section>
     </ToolLayout>
   );
 }

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -9,6 +9,14 @@ export const metadata: Metadata = {
   description:
     "Generate strong passwords, UUIDs, colors, slugs and lorem ipsum locally in your browser.",
   alternates: { canonical: "/random" },
+  keywords: [
+    "password generator",
+    "random password",
+    "uuid generator",
+    "lorem ipsum generator",
+    "slug generator",
+    "random color",
+  ],
   openGraph: {
     title: "Password Generator & Random Tools — Utilixy",
     description:
@@ -28,12 +36,95 @@ export const metadata: Metadata = {
 };
 
 export default function Page() {
+  const faq = [
+    {
+      q: "Are the passwords unique and secure?",
+      a: "Yes. They are generated with cryptographically secure randomness directly in your browser.",
+    },
+    {
+      q: "What else can I generate?",
+      a: "UUIDs, random colors, slugs and lorem ipsum text.",
+    },
+    {
+      q: "Is any data sent to a server?",
+      a: "No. All generators run entirely on your device.",
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map(({ q, a }) => ({
+      "@type": "Question",
+      name: q,
+      acceptedAnswer: { "@type": "Answer", text: a },
+    })),
+  };
+
   return (
     <ToolLayout
       title="Password Generator & Random Tools"
       description="Create strong passwords plus UUIDs, colors, slugs and lorem ipsum. Everything runs locally."
     >
+      <div className="md:col-span-2">
+        <details className="hidden md:block card p-4 md:p-6" open>
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Choose a generator (password, UUID, color, slug or lorem ipsum) and
+              configure the options. Results appear instantly with nothing sent
+              online.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Create strong passwords with chosen length and character sets.</li>
+              <li>Generate v4 UUIDs or random colors.</li>
+              <li>Produce slugs and filler text for prototypes.</li>
+            </ul>
+            <p className="mt-3">Tip: copy results with one click on each panel.</p>
+          </div>
+        </details>
+        <details className="block md:hidden card p-4 md:p-6">
+          <summary className="cursor-pointer select-none text-base font-medium">
+            What this does & how to use it
+          </summary>
+          <div className="mt-2 text-sm text-muted">
+            <p>
+              Choose a generator (password, UUID, color, slug or lorem ipsum) and
+              configure the options. Results appear instantly with nothing sent
+              online.
+            </p>
+            <ul className="list-disc pl-5 mt-3 space-y-1">
+              <li>Create strong passwords with chosen length and character sets.</li>
+              <li>Generate v4 UUIDs or random colors.</li>
+              <li>Produce slugs and filler text for prototypes.</li>
+            </ul>
+            <p className="mt-3">Tip: copy results with one click on each panel.</p>
+          </div>
+        </details>
+      </div>
+
       <Client />
+      <section id="seo-content" className="seo-half">
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg md:text-xl font-semibold mb-2">
+            Password Generator & Random Tools — FAQ
+          </h2>
+          <div className="space-y-2">
+            {faq.map(({ q, a }, i) => (
+              <details key={i} className="card--flat p-3">
+                <summary className="font-medium cursor-pointer">{q}</summary>
+                <div className="mt-2 text-sm text-muted">{a}</div>
+              </details>
+            ))}
+          </div>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      </section>
     </ToolLayout>
   );
 }


### PR DESCRIPTION
## Summary
- match Base64, Diff, Case Converter, Format, Password & QR tools to Regex page layout
- add 'What this does & how to use it' guides and FAQs for each tool
- expand metadata and keywords for stronger SEO across tools

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3da305ca0832989892ab8b49d89a8