### PR TITLE
fix: keep QR preview fixed on scroll

### DIFF
--- a/app/qr/Client.tsx
+++ b/app/qr/Client.tsx
@@ -231,7 +231,7 @@ export default function QRTool() {
       </div>
 
       {/* Right: live preview (sticky) */}
-      <div className="card p-4 md:p-6 md:sticky md:top-[88px]">
+      <div className="card p-4 md:p-6 sticky top-[88px]">
         <div className="grid place-items-center min-h-[320px]">
           {pngUrl ? (
             <img


### PR DESCRIPTION
## Summary
- keep QR code preview panel sticky so the image stays put while scrolling

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e10becb8832983daaa8661ace167