### PR TITLE
Fix conversion flow and stabilize tool navigation

### DIFF
--- a/app/image-converter/Client.tsx
+++ b/app/image-converter/Client.tsx
@@ -427,10 +427,10 @@ export default function Client() {
     return TOOLS.some((tool) => tool.id === t);
   }
 
-  const [active, setActive] = useState<ToolId>(() => {
+  const active: ToolId = useMemo(() => {
     const t = searchParams.get("tool");
-    return isToolId(t) ? t : "convert";
-  });
+    return isToolId(t) ? (t as ToolId) : "convert";
+  }, [searchParams]);
 
   // files
   const [picked, setPicked] = useState<Picked[]>([]);
@@ -513,18 +513,11 @@ export default function Client() {
     setLog([]);
   };
 
-  // Sync state when ?tool= changes (e.g., via navbar)
   useEffect(() => {
-    const t = searchParams.get("tool");
-    if (isToolId(t) && t !== active) {
-      setActive(t);
-      setActiveIdx(0);
-    }
-  }, [searchParams, active]);
+    setActiveIdx(0);
+  }, [active]);
 
   const changeTool = (next: ToolId) => {
-    setActive(next);
-    setActiveIdx(0);
     const sp = new URLSearchParams(searchParams.toString());
     sp.set("tool", next);
     router.replace(`/image-converter?${sp.toString()}`, { scroll: false });

--- a/app/pdf/Client.tsx
+++ b/app/pdf/Client.tsx
@@ -520,20 +520,12 @@ export default function PDFStudio() {
     return TOOL_LIST.some((tool) => tool.key === t);
   }
 
-  const [tool, setTool] = useState<ToolKey>(() => {
+  const tool: ToolKey = useMemo(() => {
     const t = searchParams.get("tool");
     return isToolKey(t) ? t : "batchMerge";
-  });
-
-  useEffect(() => {
-    const t = searchParams.get("tool");
-    if (isToolKey(t) && t !== tool) {
-      setTool(t);
-    }
-  }, [searchParams, tool]);
+  }, [searchParams]);
 
   const changeTool = (next: ToolKey) => {
-    setTool(next);
     const sp = new URLSearchParams(searchParams.toString());
     sp.set("tool", next);
     router.replace(`/pdf?${sp.toString()}`, { scroll: false });

--- a/app/pdf/tools/ToolDocToPdf.tsx
+++ b/app/pdf/tools/ToolDocToPdf.tsx
@@ -88,29 +88,27 @@ export default function ToolDocToPdfUX() {
           <p>
             <b>How</b>:
           </p>
-          <ol className="list-decimal pl-5 space-y-1">
-            <li>Select a .docx file.</li>
-            <li>The PDF downloads automatically after conversion.</li>
-          </ol>
-        </>
-      </ToolHelp>
-      <div className="grid md:grid-cols-[1fr_auto] gap-3 items-end">
-        <label className="block">
-          <span className="text-sm">Word document</span>
-          <input
-            type="file"
-            accept=".doc,.docx"
-            className="input mt-1"
-            onChange={(e) => {
-              const f = e.target.files?.[0];
-              if (f) {
-                setFile(f);
-                handle(f);
-              }
-            }}
-          />
-        </label>
-        {file && (
+      <ol className="list-decimal pl-5 space-y-1">
+        <li>Select a .docx file.</li>
+        <li>Click <b>Convert to PDF</b> to download.</li>
+      </ol>
+      </>
+    </ToolHelp>
+    <div className="grid md:grid-cols-[1fr_auto_auto] gap-3 items-end">
+      <label className="block">
+        <span className="text-sm">Word document</span>
+        <input
+          type="file"
+          accept=".doc,.docx"
+          className="input mt-1"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) setFile(f);
+          }}
+        />
+      </label>
+      {file && (
+        <>
           <button
             className="btn-ghost"
             onClick={() => setFile(null)}
@@ -118,10 +116,18 @@ export default function ToolDocToPdfUX() {
           >
             Clear
           </button>
-        )}
-      </div>
-      {busy && <p className="text-sm text-muted">Converting…</p>}
+          <button
+            className="btn"
+            onClick={() => file && handle(file)}
+            disabled={busy}
+          >
+            Convert to PDF
+          </button>
+        </>
+      )}
     </div>
+    {busy && <p className="text-sm text-muted">Converting…</p>}
+  </div>
   );
 }
 

--- a/app/pdf/tools/ToolPdfToDoc.tsx
+++ b/app/pdf/tools/ToolPdfToDoc.tsx
@@ -12,6 +12,7 @@ async function loadPdfJs() {
 
 export default function ToolPdfToDocUX() {
   const [busy, setBusy] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
 
   const TOOL_LABEL = "PDF to Word";
 
@@ -96,22 +97,42 @@ export default function ToolPdfToDocUX() {
           </p>
           <ol className="list-decimal pl-5 space-y-1">
             <li>Select a PDF file.</li>
-            <li>The DOCX downloads automatically after conversion.</li>
+            <li>Click <b>Convert to DOCX</b> to download.</li>
           </ol>
         </>
       </ToolHelp>
-      <label className="block">
-        <span className="text-sm">PDF file</span>
-        <input
-          type="file"
-          accept="application/pdf"
-          className="input mt-1"
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) handle(f);
-          }}
-        />
-      </label>
+      <div className="grid md:grid-cols-[1fr_auto_auto] gap-3 items-end">
+        <label className="block">
+          <span className="text-sm">PDF file</span>
+          <input
+            type="file"
+            accept="application/pdf"
+            className="input mt-1"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) setFile(f);
+            }}
+          />
+        </label>
+        {file && (
+          <>
+            <button
+              className="btn-ghost"
+              onClick={() => setFile(null)}
+              disabled={busy}
+            >
+              Clear
+            </button>
+            <button
+              className="btn"
+              onClick={() => file && handle(file)}
+              disabled={busy}
+            >
+              Convert to DOCX
+            </button>
+          </>
+        )}
+      </div>
       {busy && <p className="text-sm text-muted">Converting…</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- require explicit conversion button for Word ↔️ PDF tools
- derive active tool from URL params to eliminate sidebar flicker

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8f2f4848329be793a5795207506