### PR TITLE
fix: lock QR preview position

### DIFF
--- a/app/qr/Client.tsx
+++ b/app/qr/Client.tsx
@@ -230,22 +230,24 @@ export default function QRTool() {
         </div>
       </div>
 
-      {/* Right: live preview (sticky) */}
-      <div className="card p-4 md:p-6 sticky top-[88px]">
-        <div className="grid place-items-center min-h-[320px]">
-          {pngUrl ? (
-            <img
-              ref={imgRef}
-              src={pngUrl}
-              alt="Generated QR code"
-              width={SIZE}
-              height={SIZE}
-              className="rounded-md border border-line"
-              style={{ background: BG }}
-            />
-          ) : (
-            <div className="text-sm text-muted">Enter Wi-Fi details to generate a QR code.</div>
-          )}
+      {/* Right: live preview (fixed) */}
+      <div className="relative min-h-[320px]">
+        <div className="card p-4 md:p-6 fixed top-24 right-4 w-fit">
+          <div className="grid place-items-center min-h-[320px]">
+            {pngUrl ? (
+              <img
+                ref={imgRef}
+                src={pngUrl}
+                alt="Generated QR code"
+                width={SIZE}
+                height={SIZE}
+                className="rounded-md border border-line"
+                style={{ background: BG }}
+              />
+            ) : (
+              <div className="text-sm text-muted">Enter Wi-Fi details to generate a QR code.</div>
+            )}
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- anchor QR preview with fixed positioning so it never scrolls

## Testing
- no tests available

------
https://chatgpt.com/codex/tasks/task_e_68a4dbd12d9483298015136bfb33813e