### PR TITLE
fix: allow QR preview to scroll

### DIFF
--- a/app/qr/Client.tsx
+++ b/app/qr/Client.tsx
@@ -230,8 +230,8 @@ export default function QRTool() {
         </div>
       </div>
 
-      {/* Right: live preview (sticky) */}
-      <div className="card p-4 md:p-6 sticky top-[88px]">
+      {/* Right: live preview */}
+      <div className="card p-4 md:p-6">
         <div className="grid place-items-center min-h-[320px]">
           {pngUrl ? (
             <img


### PR DESCRIPTION
## Summary
- remove fixed positioning from QR preview so it scrolls with page

## Testing
- `npm test` (no tests found, exit code 1)


------
https://chatgpt.com/codex/tasks/task_e_68a4dbd12d9483298015136bfb33813e