### PR TITLE
Standardize FAQ layout and related links

### DIFF
--- a/app/base64/page.tsx
+++ b/app/base64/page.tsx
@@ -127,7 +127,7 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Base64 Encoder / Decoder — FAQ
@@ -140,6 +140,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>
+            <li><a className="link" href="/case-converter">Case Converter</a></li>
+            <li><a className="link" href="/diff">Diff Checker</a></li>
+            <li><a className="link" href="/qr">QR Code Generator</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"

--- a/app/base64/page.tsx
+++ b/app/base64/page.tsx
@@ -127,8 +127,11 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
-        <div className="card p-4 md:p-6">
+      <section
+        id="seo-content"
+        className="seo-full md:col-span-2 grid gap-6 md:grid-cols-2"
+      >
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Base64 Encoder / Decoder — FAQ
           </h2>
@@ -141,7 +144,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="card p-4 md:p-6">
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-2">Related tools</h2>
           <ul className="list-disc pl-5 text-sm space-y-1">
             <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>

--- a/app/case-converter/page.tsx
+++ b/app/case-converter/page.tsx
@@ -115,7 +115,7 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Case Converter — FAQ
@@ -128,6 +128,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>
+            <li><a className="link" href="/diff">Diff Checker</a></li>
+            <li><a className="link" href="/base64">Base64 Encoder / Decoder</a></li>
+            <li><a className="link" href="/regex">Regex Tester</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"

--- a/app/case-converter/page.tsx
+++ b/app/case-converter/page.tsx
@@ -115,8 +115,11 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
-        <div className="card p-4 md:p-6">
+      <section
+        id="seo-content"
+        className="seo-full md:col-span-2 grid gap-6 md:grid-cols-2"
+      >
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Case Converter — FAQ
           </h2>
@@ -129,7 +132,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="card p-4 md:p-6">
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-2">Related tools</h2>
           <ul className="list-disc pl-5 text-sm space-y-1">
             <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>

--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -130,7 +130,7 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Text Difference Checker — FAQ
@@ -143,6 +143,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>
+            <li><a className="link" href="/case-converter">Case Converter</a></li>
+            <li><a className="link" href="/base64">Base64 Encoder / Decoder</a></li>
+            <li><a className="link" href="/qr">QR Code Generator</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"

--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -130,8 +130,11 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
-        <div className="card p-4 md:p-6">
+      <section
+        id="seo-content"
+        className="seo-full md:col-span-2 grid gap-6 md:grid-cols-2"
+      >
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Text Difference Checker — FAQ
           </h2>
@@ -144,7 +147,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="card p-4 md:p-6">
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-2">Related tools</h2>
           <ul className="list-disc pl-5 text-sm space-y-1">
             <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>

--- a/app/format/page.tsx
+++ b/app/format/page.tsx
@@ -103,7 +103,7 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             JSON / YAML / XML Formatter — FAQ
@@ -116,6 +116,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/case-converter">Case Converter</a></li>
+            <li><a className="link" href="/diff">Diff Checker</a></li>
+            <li><a className="link" href="/base64">Base64 Encoder / Decoder</a></li>
+            <li><a className="link" href="/regex">Regex Tester</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"

--- a/app/format/page.tsx
+++ b/app/format/page.tsx
@@ -103,8 +103,11 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-full md:col-span-2 grid gap-6">
-        <div className="card p-4 md:p-6">
+      <section
+        id="seo-content"
+        className="seo-full md:col-span-2 grid gap-6 md:grid-cols-2"
+      >
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             JSON / YAML / XML Formatter — FAQ
           </h2>
@@ -117,7 +120,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="card p-4 md:p-6">
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-2">Related tools</h2>
           <ul className="list-disc pl-5 text-sm space-y-1">
             <li><a className="link" href="/case-converter">Case Converter</a></li>

--- a/app/globals.css
+++ b/app/globals.css
@@ -794,7 +794,7 @@ main:has(#seo-content) .tool-panels{
 }
 
 /* Safety: ensure nothing inside the card re-introduces top spacing */
-#seo-content > .card { margin: 0 auto !important; }
+#seo-content > .card { margin: 0; }
 #seo-content > *:first-child { margin-top: 0 !important; }
 /* === PDF: put the SEO block snug under the tool, right column === */
 /* Target the actual grid item that WRAPS #seo-content */

--- a/app/globals.css
+++ b/app/globals.css
@@ -819,18 +819,6 @@ main:has(#seo-content) .tool-panels{
   }
 }
 
-/* === Non-PDF tools (e.g. Image Converter): make SEO block full width === */
-@media (min-width: 768px){
-  :not([data-pdf]) .tool-panels > .seo-half{
-    grid-column: 1 / -1 !important;
-    margin-top: 0 !important;
-  }
-  :not([data-pdf]) #seo-content{
-    grid-column: 1 / -1 !important;
-    margin-top: 0 !important;
-  }
-}
-
 /* Image Studio: keep FAQ aligned with results column */
 @media (min-width: 768px){
   [data-image] #seo-content{
@@ -840,6 +828,17 @@ main:has(#seo-content) .tool-panels{
 
 /* Image Studio: don't center the FAQ card */
 [data-image] #seo-content > .card { margin: 0 !important; }
+
+/* Full-width SEO block (FAQ + related links) */
+.tool-panels > .seo-full#seo-content{
+  grid-column: 1 / -1 !important;
+  margin-top: -1.25rem !important;
+}
+@media (min-width: 1024px){
+  .tool-panels > .seo-full#seo-content{
+    margin-top: -1.75rem !important;
+  }
+}
 
 /* Hide the ToolLayout heading/intro on pages that render #seo-content
    (PDF Studio, Image Converter, and any future tool with an FAQ block) */

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -106,7 +106,7 @@ export default function Page() {
 
       <Client />
 
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-half grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">Wi-Fi QR Code Generator — FAQ</h2>
           <div className="space-y-2">
@@ -117,6 +117,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/random">Password Generator</a></li>
+            <li><a className="link" href="/base64">Base64 Encoder / Decoder</a></li>
+            <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>
+            <li><a className="link" href="/case-converter">Case Converter</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -106,7 +106,10 @@ export default function Page() {
 
       <Client />
 
-      <section id="seo-content" className="seo-half grid gap-6">
+      <section
+        id="seo-content"
+        className="seo-half grid gap-6 md:!-mt-8 lg:!-mt-12"
+      >
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">Wi-Fi QR Code Generator — FAQ</h2>
           <div className="space-y-2">

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -106,8 +106,11 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half grid gap-6">
-        <div className="card p-4 md:p-6">
+      <section
+        id="seo-content"
+        className="seo-half grid gap-6 md:!mt-4"
+      >
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Password Generator & Random Tools — FAQ
           </h2>
@@ -120,7 +123,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="card p-4 md:p-6">
+        <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg font-semibold mb-2">Related tools</h2>
           <ul className="list-disc pl-5 text-sm space-y-1">
             <li><a className="link" href="/qr">QR Code Generator</a></li>

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -108,7 +108,7 @@ export default function Page() {
       <Client />
       <section
         id="seo-content"
-        className="seo-half grid gap-6 md:!mt-4"
+        className="seo-half grid gap-6 mt-8 md:!mt-12"
       >
         <div className="card w-full p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -106,7 +106,7 @@ export default function Page() {
       </div>
 
       <Client />
-      <section id="seo-content" className="seo-half">
+      <section id="seo-content" className="seo-half grid gap-6">
         <div className="card p-4 md:p-6">
           <h2 className="text-lg md:text-xl font-semibold mb-2">
             Password Generator & Random Tools — FAQ
@@ -119,6 +119,15 @@ export default function Page() {
               </details>
             ))}
           </div>
+        </div>
+        <div className="card p-4 md:p-6">
+          <h2 className="text-lg font-semibold mb-2">Related tools</h2>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            <li><a className="link" href="/qr">QR Code Generator</a></li>
+            <li><a className="link" href="/base64">Base64 Encoder / Decoder</a></li>
+            <li><a className="link" href="/format">JSON / YAML / XML Formatter</a></li>
+            <li><a className="link" href="/case-converter">Case Converter</a></li>
+          </ul>
         </div>
         <script
           type="application/ld+json"


### PR DESCRIPTION
## Summary
- Add `seo-full` style for full-width FAQ sections
- Standardize FAQ placement and add Related tools links across utilities
- Keep QR and password tools’ FAQs beneath their respective outputs

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e2aed7608329b667623059ff38c8