### PR TITLE
Refine layout alignment and mobile ad spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,6 +48,12 @@ a{ text-underline-offset:3px; }
 /* globals.css – make existing .container-wrap actually center */
 .container-wrap{ max-width:1160px; width:100%; margin-left:auto; margin-right:auto; }
 
+/* Ad slot wrapper: reduce reserved space on small screens */
+.ad-slot{ min-height:var(--ad-min); }
+@media (max-width:640px){
+  .ad-slot:not(.ad-fixed){ min-height:calc(var(--ad-min)*0.6); }
+}
+
 /* Reusable brand gradient (keep for footer) */
 .brand-gradient{ background-image:linear-gradient(to bottom,#1e3a8a 0%,#2563eb 45%,#3b82f6 100%); }
 

--- a/components/ToolLayout.tsx
+++ b/components/ToolLayout.tsx
@@ -44,7 +44,7 @@ export default function ToolLayout({
       transition={{ duration: 0.3 }}
     >
       {/* Header: same width as content */}
-      <div className="mx-auto w-full max-w-7xl px-4 md:px-6 lg:px-8">
+      <div className="container-wrap px-4 md:px-6 lg:px-8">
         <div
           className={
             center
@@ -66,7 +66,7 @@ export default function ToolLayout({
       </div>
 
       {/* Panels wrapper */}
-      <div className="mx-auto w-full max-w-7xl px-4 md:px-6 lg:px-8 mt-6">
+      <div className="container-wrap px-4 md:px-6 lg:px-8 mt-6">
         <div className="tool-panels">{items}</div>
       </div>
     </motion.section>

--- a/components/ads/AdSlot.tsx
+++ b/components/ads/AdSlot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, CSSProperties } from "react";
 
 type AdSlotProps = {
   slotId: string;
@@ -41,33 +41,34 @@ useEffect(() => {
 }, []);
 
 
- const style: React.CSSProperties =
-  width && height ? { display, width, height } : { display: "block" };
+  const wrapperClass = `ad-slot flex justify-center items-center overflow-hidden ${className || ""} ${
+    width && height ? "ad-fixed" : ""
+  }`;
 
-return (
-  <div
-    className={`flex justify-center items-center overflow-hidden ${className || ""}`}
-    style={{
-      minHeight: minHeight ? `${minHeight}px` : undefined,
-      width: width ? `${width}px` : "100%",
-      height: height ? `${height}px` : "auto",
-    }}
-  >
-    <ins
-      className="adsbygoogle"
+  return (
+    <div
+      className={wrapperClass}
       style={{
-        display: display || "block",
+        ["--ad-min" as any]: minHeight ? `${minHeight}px` : undefined,
         width: width ? `${width}px` : "100%",
         height: height ? `${height}px` : "auto",
-      }}
-      data-ad-client="ca-pub-1257499604453174"
-      data-ad-slot={slotId}
-      {...(format ? { "data-ad-format": format } : {})}
-      {...(responsive ? { "data-full-width-responsive": "true" } : {})}
-      {...(lazy ? { "data-loading-strategy": "lazy" } : {})}
-      ref={adRef as unknown as React.RefObject<HTMLModElement>}
-    ></ins>
-  </div>
-);
+      } as CSSProperties}
+    >
+      <ins
+        className="adsbygoogle"
+        style={{
+          display: display || "block",
+          width: width ? `${width}px` : "100%",
+          height: height ? `${height}px` : "auto",
+        }}
+        data-ad-client="ca-pub-1257499604453174"
+        data-ad-slot={slotId}
+        {...(format ? { "data-ad-format": format } : {})}
+        {...(responsive ? { "data-full-width-responsive": "true" } : {})}
+        {...(lazy ? { "data-loading-strategy": "lazy" } : {})}
+        ref={adRef as unknown as React.RefObject<HTMLModElement>}
+      ></ins>
+    </div>
+  );
 
 }


### PR DESCRIPTION
## Summary
- Unify tool page layout with global container to keep widths consistent
- Reduce mobile ad gap via responsive CSS and updated ad slot wrapper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a50464587c83299ae588f89e920514