### PR TITLE
chore: disable ad slots and remove footer gap

### DIFF
--- a/app/case-converter/Client.tsx
+++ b/app/case-converter/Client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import Ad from '@/components/ads/Ad';
+// import Ad from '@/components/ads/Ad'; // ads disabled
 
 type Mode =
   | 'upper'

--- a/app/format/Client.tsx
+++ b/app/format/Client.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import yaml from 'js-yaml';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
-import Ad from '@/components/ads/Ad';
+// import Ad from '@/components/ads/Ad'; // ads disabled
 
 type Mode = 'auto' | 'json' | 'yaml' | 'xml';
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import ToolMenuWrapper from "@/components/ToolMenuWrapper";
 import ThemeToggle from "@/components/ThemeToggle";
-import FooterMultiplex from "@/components/ads/FooterMultiplex";
+// import FooterMultiplex from "@/components/ads/FooterMultiplex"; // ads disabled
 import { Suspense } from "react";
 import AnimatedMain from "@/components/AnimatedMain";
 
@@ -229,8 +229,8 @@ export default function RootLayout({
             {children}
           </AnimatedMain>
 
-          {/* Multiplex above footer on tool pages */}
-          <FooterMultiplex />
+          {/* Multiplex ad removed for now */}
+          {false && <></>}
 
           {/* Neutral footer */}
           <footer className="border-t border-line bg-[hsl(var(--card))]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import Ad from "@/components/ads/Ad"; // Multiplex wrapper
+// Ads temporarily disabled
 
 export const metadata: Metadata = {
   title: "PDF Studio & Web Tools — Utilixy",
@@ -209,16 +209,18 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* NEW: Ad between hero and tools (outside hero) */}
-      <section className="mt-2">
-        <Ad
-          slot="belowHero"
-          format="auto" // auto size
-          responsive={true} // full-width responsive
-          minHeight={60} // smaller reserved space when ads don't fill
-          className="mx-auto w-full"
-        />
-      </section>
+      {/* Ad removed for now */}
+      {false && (
+        <section className="mt-2">
+          {/* <Ad
+            slot="belowHero"
+            format="auto"
+            responsive={true}
+            minHeight={60}
+            className="mx-auto w-full"
+          /> */}
+        </section>
+      )}
 
       {/* Tools grid */}
       <section id="tools" className="grid gap-5">
@@ -285,10 +287,12 @@ export default function HomePage() {
         />
       </section>
 
-      {/* Homepage bottom ad: Multiplex, out of the way */}
-      <section className="mt-6">
-        <Ad slot="homeMultiplex" format="autorelaxed" minHeight={150} />
-      </section>
+      {/* Bottom ad removed for now */}
+      {false && (
+        <section className="mt-6">
+          {/* <Ad slot="homeMultiplex" format="autorelaxed" minHeight={150} /> */}
+        </section>
+      )}
     </div>
   );
 }

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -1,7 +1,7 @@
 import ToolLayout from "@/components/ToolLayout";
 import type { Metadata } from "next";
 import Client from "./Client";
-import Ad from "@/components/ads/Ad"; // multiplex wrapper
+// import Ad from "@/components/ads/Ad"; // ads disabled
 
 export const metadata: Metadata = {
   title: "Wi-Fi QR Code Generator — Utilixy",

--- a/app/random/page.tsx
+++ b/app/random/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import ToolLayout from "@/components/ToolLayout";
 import Client from "./Client";
-import Ad from "@/components/ads/Ad";
+// import Ad from "@/components/ads/Ad"; // ads disabled
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/components/ToolMenu.tsx
+++ b/components/ToolMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import Ad from '@/components/ads/Ad';
+// import Ad from '@/components/ads/Ad';
 
 const tools = [
   { href: '/', label: 'Home' },
@@ -42,19 +42,21 @@ export default function ToolMenu({ onClose }: { onClose: () => void }) {
           </Link>
         ))}
 
-        {/* Tower ad renders only when menu is open, because ToolMenu mounts only then */}
-        <div className="mt-6 flex justify-center">
-          <Ad
-            slot="sidebarTower"
-            responsive={false}
-            format={null}           // omit data-ad-format for fixed size
-            width={250}
-            height={600}
-            display="inline-block"
-            minHeight={600}
-            lazy
-          />
-        </div>
+        {/* Tower ad removed for now */}
+        {false && (
+          <div className="mt-6 flex justify-center">
+            {/* <Ad
+              slot="sidebarTower"
+              responsive={false}
+              format={null}
+              width={250}
+              height={600}
+              display="inline-block"
+              minHeight={600}
+              lazy
+            /> */}
+          </div>
+        )}
       </nav>
 
       <div className="absolute bottom-0 left-0 right-0 border-t border-line p-3 text-xs text-muted">

--- a/components/ads/Ad.tsx
+++ b/components/ads/Ad.tsx
@@ -26,6 +26,8 @@ export default function Ad({
   height,
   display,
 }: Props) {
+  return null; // ads disabled
+  /*
   return (
     <AdSlot
       slotId={SLOTS[slot]}
@@ -39,4 +41,5 @@ export default function Ad({
       display={display}
     />
   );
+  */
 }


### PR DESCRIPTION
## Summary
- hide all ad components including footer multiplex
- remove ad placeholder sections that left extra space
- ensure Ad component returns null
- remove unused footer multiplex reference

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5168232108329b95899b8766820a3