### PR TITLE
Add QuickCalc links to hero and footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   title: "Utilixy — Quick, private web tools",
   description:
-    "QR & Wi-Fi codes, image and PDF tools, formatters and random generators — all running locally in your browser.",
+    "QR & Wi-Fi codes, image and PDF tools, formatters and random generators — all running locally in your browser. Explore QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
   manifest: "/manifest.json",
   themeColor: "#3B82F6",
   metadataBase: new URL("https://utilixy.com"),
@@ -53,11 +53,17 @@ export const metadata: Metadata = {
     "Base64 encoder",
     "random generator",
     "regex tester",
+    "QuickCalc",
+    "BMI calculator",
+    "mortgage calculator",
+    "loan calculator",
+    "age calculator",
+    "holiday calculator",
   ],
   openGraph: {
     title: "Utilixy — Quick, private web tools",
     description:
-      "All tools run locally. Generate QR codes, convert images, merge PDFs, format JSON/YAML/XML, and more.",
+      "All tools run locally. Generate QR codes, convert images, merge PDFs, format JSON/YAML/XML, and more. Explore QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
     type: "website",
   },
@@ -65,7 +71,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Utilixy — Quick, private web tools",
     description:
-      "All tools run locally. Generate QR codes, convert images, merge PDFs, format JSON/YAML/XML, and more.",
+      "All tools run locally. Generate QR codes, convert images, merge PDFs, format JSON/YAML/XML, and more. Explore QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
     images: ["/icons/icon-512.png"],
   },
 };
@@ -250,6 +256,14 @@ export default function RootLayout({
                   <Link href="/about" className="hover:underline leading-none">
                     About
                   </Link>
+                  <a
+                    href="https://quickcalc.me"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:underline leading-none"
+                  >
+                    QuickCalc
+                  </a>
                 </nav>
                 <div className="flex items-center">
                   <ThemeToggle />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "PDF Studio & Web Tools — Utilixy",
   description:
-    "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
+    "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects. Need calculators? Visit QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
   keywords: [
     "PDF Studio",
     "web tools",
@@ -22,11 +22,17 @@ export const metadata: Metadata = {
     "no sign up",
     "no pop ups",
     "no redirects",
+    "QuickCalc",
+    "BMI calculator",
+    "mortgage calculator",
+    "loan calculator",
+    "age calculator",
+    "holiday calculator",
   ],
   openGraph: {
     title: "PDF Studio & Web Tools — Utilixy",
     description:
-      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
+      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects. Need calculators? Visit QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
     url: "/",
     siteName: "Utilixy",
     images: [{ url: "/icons/icon-512.png", width: 512, height: 512 }],
@@ -36,7 +42,7 @@ export const metadata: Metadata = {
     card: "summary",
     title: "PDF Studio & Web Tools — Utilixy",
     description:
-      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects.",
+      "Reorder, rotate, merge and split PDFs plus access quick tools like QR codes, image conversion and more — all local, private and free. No sign-up, pop-ups or redirects. Need calculators? Visit QuickCalc for BMI, mortgage, loan, age and holiday calculators.",
     images: ["/icons/icon-512.png"],
   },
 };
@@ -150,20 +156,33 @@ export default function HomePage() {
               </b>
             </p>
             {/* CTAs */}
-            <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-              <Link href="/pdf" className="btn">
-                Open PDF Studio
-              </Link>
-              <Link href="/image-converter" className="btn">
-                Open Image Studio
-              </Link>
-              <a href="#tools" className="btn">
-                Browse all tools
-              </a>
-            </div>
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+                <Link href="/pdf" className="btn">
+                  Open PDF Studio
+                </Link>
+                <Link href="/image-converter" className="btn">
+                  Open Image Studio
+                </Link>
+                <a href="#tools" className="btn">
+                  Browse all tools
+                </a>
+              </div>
 
-            {/* Mention other tools inline */}
-            <div className="mt-2 flex flex-wrap items-center justify-center gap-2 text-sm">
+              <p className="mx-auto mt-2 max-w-[70ch] text-sm">
+                Need calculators? Visit{" "}
+                <a
+                  href="https://quickcalc.me"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  QuickCalc
+                </a>{" "}
+                for BMI, mortgage, loan, age and holiday calculators.
+              </p>
+
+              {/* Mention other tools inline */}
+              <div className="mt-2 flex flex-wrap items-center justify-center gap-2 text-sm">
               {[
                 { href: "/qr", label: "QR & Wi‑Fi" },
                 { href: "/image-converter", label: "Image converter" },


### PR DESCRIPTION
## Summary
- mention QuickCalc calculators in home page metadata and hero
- add QuickCalc link to global footer with SEO keywords

## Testing
- `npm test` (fails: No tests found, exiting with code 1)

------
https://chatgpt.com/codex/tasks/task_e_68a8852bca948329aa50e4e06d2f20ab